### PR TITLE
Some fixes to the Bluenet library

### DIFF
--- a/src/core/ble/Scanner.ts
+++ b/src/core/ble/Scanner.ts
@@ -14,7 +14,7 @@ const noble = require('noble');
 
 export class Scanner {
 
-  nobleState = 'unknown';
+  nobleState = noble.state;
   scanningInProgress = false;
   trackedStones : TrackerMap = {};
   cache : Cache = {};
@@ -141,7 +141,8 @@ export class Scanner {
     if ( !advertisement.serviceDataAvailable ) { return }
 
     // decrypt the advertisement
-    if (this.settings.encryptionEnabled) {
+    let opType = peripheral.advertisement.serviceData[0].data.readUInt8(0);
+    if (opType!==6 && this.settings.encryptionEnabled) {
       advertisement.decrypt(this.settings.basicKey);
     }
     else {

--- a/src/packets/ServiceData.ts
+++ b/src/packets/ServiceData.ts
@@ -91,14 +91,17 @@ export class ServiceData {
           break;
         case 4:
           parseOpCode4(this, this.encryptedData);
+          this.setupMode = true;
           break;
         case 5:
         case 7:
           this.getDeviceTypeFromPublicData();
+          this.setupMode = false;
           parseOpCode5(this, this.encryptedData);
           break;
         case 6:
           this.getDeviceTypeFromPublicData();
+          this.setupMode = true;
           parseOpCode6(this, this.encryptedData);
           break;
         default:


### PR DESCRIPTION
Team, 
While developing a NodeRed node for Crownstone, I stumbled across some irregularlies.
This pull request is merely a way to point out where some issues arrised.
Hopefully you are able to fix it sometime.

The solved issues:
- Get initial state from Noble instead of assuming `unknown`. This solves waiting for an onStateChange, but it never happens when Noble is `poweredOn` already
- Disable encryption check for Crownstones in setup mode
- Set setupMode flag correctly, based on device type

Keep up the good work,
Kind regards